### PR TITLE
Correct the rotation and placement of text in figures with inverted y-axis

### DIFF
--- a/curlyBrace.py
+++ b/curlyBrace.py
@@ -500,25 +500,37 @@ def curlyBrace(fig, ax, p1, p2, k_r=0.1, bool_auto=True, str_text='', int_line_n
 
         if (ang >= 0.0) and (ang <= 90.0):
 
-            rotation = ang
-
-            str_text = str_text + str_temp
+            if ax_ylim[0] < ax_ylim[1]:
+                rotation = ang
+                str_text = str_text + str_temp
+            else:
+                rotation = -ang
+                str_text = str_temp + str_text
 
         if (ang > 90.0) and (ang < 270.0):
 
-            rotation = ang + 180.0
-
-            str_text = str_temp + str_text
+            if ax_ylim[0] < ax_ylim[1]:
+                rotation = ang + 180.0
+                str_text = str_temp + str_text
+            else:
+                rotation = -(ang + 180.0)
+                str_text = str_text + str_temp
 
         elif (ang >= 270.0) and (ang <= 360.0):
 
-            rotation = ang
-
-            str_text = str_text + str_temp
+            if ax_ylim[0] < ax_ylim[1]:
+                rotation = ang
+                str_text = str_text + str_temp
+            else:
+                rotation = -ang
+                str_text = str_temp + str_text
 
         else:
 
-            rotation = ang
+            if ax_ylim[0] < ax_ylim[1]:
+                rotation = ang
+            else:
+                rotation = -ang
 
         ax.axes.text(arc2x[-1], arc2y[-1], str_text, ha='center', va='center', rotation=rotation, fontdict=fontdict)
 

--- a/exp_inverted_axis.py
+++ b/exp_inverted_axis.py
@@ -1,0 +1,31 @@
+"""Simple example of curlyBrace in a figure with inverted y-axis.
+
+Author: Markus Reinert
+Last Modified: 2022-03-23
+"""
+
+import matplotlib.pyplot as plt
+
+from curlyBrace import curlyBrace
+
+
+save_figure = False
+
+
+fig, axs = plt.subplots(ncols=2, figsize=(8, 4))
+
+axs[0].set_title("vertical axis normal")
+axs[0].set_ylim(-2, +2)
+axs[0].scatter([0, 1], [-0.5, 0.5])
+curlyBrace(fig, axs[0], (1, 0.5), (0, -0.5), str_text="Hello curly brace!", color="black")
+
+axs[1].set_title("vertical axis increasing downwards")
+axs[1].set_ylim(+2, -2)
+axs[1].scatter([0, 1], [-0.5, 0.5])
+curlyBrace(fig, axs[1], (1, 0.5), (0, -0.5), str_text="Hello curly brace!", color="black")
+
+if save_figure:
+    import os
+    fig.savefig(os.path.basename(__file__).replace(".py", ".png"))
+
+plt.show()


### PR DESCRIPTION
With this proposed change, the text label of a curly brace is at the correct position and in the correct rotation, even for figures with inverted y-axis.

A new example script is added, showing how curly brace works with a normal and an inverted y-axis:

Figure produced with the code on the current master branch:
![A figure with an inverted y-axis with the current code on “master”.](https://user-images.githubusercontent.com/55705810/159887766-7bd0e86a-5a9c-411f-b6f0-1f632d0320b6.png)

Figure produced with the code of this pull request:
![The same figure with an inverted y-axis with the code of this pull request.](https://user-images.githubusercontent.com/55705810/159887771-390bbda3-7a78-4549-a03a-e30727c5818a.png)
.