### PR TITLE
Make curly braces always single-colored

### DIFF
--- a/curlyBrace.py
+++ b/curlyBrace.py
@@ -478,7 +478,8 @@ def curlyBrace(fig, ax, p1, p2, k_r=0.1, bool_auto=True, str_text='', int_line_n
         pass
 
     # plot arcs
-    ax.plot(arc1x, arc1y, **kwargs)
+    l, = ax.plot(arc1x, arc1y, **kwargs)
+    kwargs["color"] = l.get_color()
     ax.plot(arc2x, arc2y, **kwargs)
     ax.plot(arc3x, arc3y, **kwargs)
     ax.plot(arc4x, arc4y, **kwargs)

--- a/exp_color.py
+++ b/exp_color.py
@@ -1,0 +1,27 @@
+"""Simple example of curlyBrace with automatic colors.
+
+Author: Markus Reinert
+Last Modified: 2022-03-23
+"""
+
+import matplotlib.pyplot as plt
+
+from curlyBrace import curlyBrace
+
+
+save_figure = False
+
+
+fig, ax = plt.subplots()
+ax.set_ylim(2, 12)
+ax.set_xlim(-1, 1)
+for i in range(12):
+    # The color of the curlyBrace is not given explicitly,
+    # but determined automatically by matplotlib's color rotation
+    curlyBrace(fig, ax, (-1, i), (1, i))
+
+if save_figure:
+    import os
+    fig.savefig(os.path.basename(__file__).replace(".py", ".png"))
+
+plt.show()


### PR DESCRIPTION
Before this commit, if the optional “color” keyword was not given, then the curly brace would have several, seemingly random colors.  This two-line fix ensures that a curly brace has always a single color, either given as the keyword argument or determined automatically.

A new example script making use of this is added.  The result of this example script looks like this:
![Result of exp_color.py with the code from this pull request.](https://user-images.githubusercontent.com/55705810/159889080-8aa1b1a3-9fc2-46bb-9782-653b4a944c67.png)
Since the script does not specify the colors of the curly braces, they are chosen automatically based on the color rotation of matplotlib.

The same example script with the code that is currently on the master branch creates the following output:
![Result of exp_color.py with the code from the master branch.](https://user-images.githubusercontent.com/55705810/159889372-059fe70b-8a29-415d-a483-119594d0d046.png)
Here, each curly brace has several colors, which creates a non-uniform appearance.
